### PR TITLE
textColor 赋值使用 MSImmutableColor

### DIFF
--- a/WeSketch.sketchplugin/Contents/Sketch/colorReplace.js
+++ b/WeSketch.sketchplugin/Contents/Sketch/colorReplace.js
@@ -155,7 +155,7 @@ function colorReplace(context) {
     }
     if ('#' + textcolor.hexValue() == colorToFind) {
       replaceCount++;
-      layer.textColor = MSColor.colorWithRed_green_blue_alpha(colorToReplace.r / 255, colorToReplace.g / 255, colorToReplace.b / 255, 1.0);
+      layer.textColor = MSImmutableColor.colorWithRed_green_blue_alpha(colorToReplace.r / 255, colorToReplace.g / 255, colorToReplace.b / 255, 1.0);
     }
   }
 
@@ -269,7 +269,7 @@ function colorReplace(context) {
   }
 
   if (replaceCount) {
-    context.document.showMessage('替换成功，共找到' + replaceCount + '处\r\n');
+    context.document.showMessage('替换成功，共找到' + replaceCount + '处');
   } else {
     context.document.showMessage('没有找到需要替换的颜色');
   }


### PR DESCRIPTION
1. 使用 MSColor 会导致 Sketch 48 发生闪退
2. 删除了替换成功提示文案末尾的“\r\n”，之前会让消息产生空行，显得很不美观